### PR TITLE
Preserve PyPose LieTensor semantics in TrackingTensor

### DIFF
--- a/bae/autograd/function.py
+++ b/bae/autograd/function.py
@@ -2,13 +2,83 @@ import torch
 import numpy as np
 import pypose as pp
 
-WHITELISTED_MAPS = (torch._C.TensorBase.__add__, 
-                    torch._C.TensorBase.__sub__, 
-                    torch._C.TensorBase.__mul__, 
-                    torch._C.TensorBase.__div__,
-                    torch._C.TensorBase.add,
-                    torch._C.TensorBase.sub,
-                    torch._C.TensorBase.mul,)
+WHITELISTED_MAPS = tuple(
+    func for func in (
+        torch._C.TensorBase.__add__,
+        torch._C.TensorBase.__sub__,
+        torch._C.TensorBase.__mul__,
+        getattr(torch._C.TensorBase, "__div__", None),
+        torch._C.TensorBase.add,
+        torch._C.TensorBase.sub,
+        torch._C.TensorBase.mul,
+    ) if func is not None
+)
+
+_LTYPE_PRESERVING_FUNCS = {
+    torch._C.TensorBase.__getitem__,
+    torch.cat,
+    *WHITELISTED_MAPS,
+    torch._C.TensorBase.clone,
+    torch._C.TensorBase.to,
+}
+
+
+def _iter_tracked_tensors(values):
+    if isinstance(values, torch.Tensor):
+        yield values
+    elif isinstance(values, (tuple, list)):
+        for value in values:
+            yield from _iter_tracked_tensors(value)
+
+
+def _merge_optrace(values):
+    merged_optrace = {}
+    for value in _iter_tracked_tensors(values):
+        if hasattr(value, 'optrace'):
+            merged_optrace.update(value.optrace)
+    return merged_optrace
+
+
+def _attach_index_trace(result, index, tensor):
+    if not hasattr(result, 'optrace'):
+        result.optrace = {}
+    result.optrace[id(result)] = ("index", index, tensor)
+    return result
+
+
+def _attach_cat_trace(result, tensors, dim):
+    merged_optrace = _merge_optrace(tensors)
+    merged_optrace[id(result)] = ("cat", dim, tuple(tensors))
+    result.optrace = merged_optrace
+    return result
+
+
+def _attach_map_trace(result, func, args):
+    merged_optrace = _merge_optrace(args)
+    merged_optrace[id(result)] = ("map", func, args)
+    result.optrace = merged_optrace
+    return result
+
+
+def _find_tracking_source(values, cls):
+    for value in _iter_tracked_tensors(values):
+        if isinstance(value, cls):
+            return value
+    return None
+
+
+def _retain_ltype(result, tracking_source, cls, func):
+    if tracking_source is None or not issubclass(cls, pp.LieTensor):
+        return result
+    if func not in _LTYPE_PRESERVING_FUNCS:
+        return result
+    if not isinstance(result, torch.Tensor) or isinstance(result, cls):
+        return result
+    if result.shape[-1:] != tracking_source.ltype.dimension:
+        return result
+    wrapped = torch.Tensor.as_subclass(result, cls)
+    wrapped.ltype = tracking_source.ltype
+    return wrapped
 
 # =============================================================================
 # Class: IndexTrackingTensor
@@ -18,49 +88,34 @@ WHITELISTED_MAPS = (torch._C.TensorBase.__add__,
 class TrackingTensor(torch.Tensor):
     @staticmethod
     def __new__(cls, data, *args, **kwargs):
+        if cls is TrackingTensor and isinstance(data, pp.LieTensor):
+            return _TrackingLieTensor(data, *args, **kwargs)
+
         if isinstance(data, torch.Tensor):
-            instance = torch.Tensor._make_subclass(cls, data, *args, **kwargs)
-        else:
-            instance = torch.Tensor._make_subclass(cls, torch.as_tensor(data), *args, **kwargs)
-        return instance
+            return torch.Tensor._make_subclass(cls, data, *args, **kwargs)
+        return torch.Tensor._make_subclass(cls, torch.as_tensor(data), *args, **kwargs)
 
 
     @classmethod
     def __torch_function__(cls, func, types, args=(), kwargs=None):
+        if kwargs is None:
+            kwargs = {}
         result = super(TrackingTensor, cls).__torch_function__(func, types, args=args, kwargs=kwargs)
-        
-        if isinstance(result, torch.Tensor) and getattr(args[0], '_active', True):
-            # print(f"__torch_function__ called with {func}")
+        result = _retain_ltype(result, _find_tracking_source(args, cls), cls, func)
+
+        if isinstance(result, torch.Tensor) and (not args or getattr(args[0], '_active', True)):
             if (func == torch._C.TensorBase.__getitem__) and isinstance(args[1], torch.Tensor):
-                if not hasattr(result, 'optrace'):
-                    result.optrace = {}
-                index_edge = ("index", args[1], args[0])
-                result.optrace[id(result)] = index_edge
+                result = _attach_index_trace(result, args[1], args[0])
             elif func == torch.cat:
-                if kwargs is None:
-                    kwargs = {}
                 tensors = args[0]
                 dim = kwargs.get("dim", 0)
                 if len(args) > 1:
                     dim = args[1]
                 if dim != 0:
                     raise NotImplementedError("TrackingTensor only supports torch.cat(..., dim=0)")
-
-                merged_optrace = {}
-                for t in tensors:
-                    if isinstance(t, torch.Tensor) and hasattr(t, 'optrace'):
-                        merged_optrace.update(t.optrace)
-
-                merged_optrace[id(result)] = ("cat", 0, tuple(tensors))
-                result.optrace = merged_optrace
+                result = _attach_cat_trace(result, tensors, dim)
             elif func in WHITELISTED_MAPS:
-                merged_optrace = {}
-                for arg in args:
-                    if isinstance(arg, torch.Tensor) and hasattr(arg, 'optrace'):
-                        merged_optrace.update(arg.optrace)
-
-                merged_optrace[id(result)] = ("map", func, args)
-                result.optrace = merged_optrace
+                result = _attach_map_trace(result, func, args)
         return result
     
     def __getitem__(self, index):
@@ -95,6 +150,25 @@ class TrackingTensor(torch.Tensor):
         
     def tensor(self) -> torch.Tensor:
         return torch.Tensor.as_subclass(self, torch.Tensor)
+
+
+class _TrackingLieTensor(TrackingTensor, pp.LieTensor):
+    def __init__(self, data=None, *args, **kwargs):
+        if isinstance(data, pp.LieTensor):
+            self.ltype = data.ltype
+
+    @staticmethod
+    def __new__(cls, data, *args, **kwargs):
+        if not isinstance(data, pp.LieTensor):
+            raise TypeError(f"_TrackingLieTensor expects a LieTensor input, got {type(data)!r}")
+        instance = torch.Tensor.as_subclass(data, cls)
+        instance.ltype = data.ltype
+        return instance
+
+    def detach(self):
+        detached = torch.Tensor.as_subclass(super().detach(), type(self))
+        detached.ltype = self.ltype
+        return detached
 """
 graph design
 Node: (tensor_type: [nn.Parameter, tensor, pp.LieTensor])
@@ -127,12 +201,7 @@ recusively call 1-3 until input node is reached.
 # =============================================================================
 def index_transform(tensor, index):
     result = tensor[index]
-    if not hasattr(result, 'optrace'):
-        result.optrace = {}
-    # index edge (edge_type, indicies, orig_arg)
-    index_edge = ("index", index, tensor)
-    result.optrace[id(result)] = index_edge
-    return result
+    return _attach_index_trace(result, index, tensor)
 
 
 # =============================================================================
@@ -146,14 +215,7 @@ def map_transform(func):
         result = func(*args, **kwargs)
         # map edge (edge_type, func, [input_args])
         # ensure final result is an IndexTrackingTensor
-        merged_optrace = {}
-        for arg in args:
-            if isinstance(arg, torch.Tensor) and hasattr(arg, 'optrace'):
-                merged_optrace.update(arg.optrace)
-
-        merged_optrace[id(result)] = ("map", func, args)
-        result.optrace = merged_optrace
-        return result
+        return _attach_map_trace(result, func, args)
     return wrapper
 
     # map_transform(vmap(func))

--- a/bae/autograd/graph.py
+++ b/bae/autograd/graph.py
@@ -6,6 +6,7 @@ import torch
 from torch.func import jacrev
 
 from ..sparse import warp_wrappers as _warp_wrappers  # noqa: F401
+from ..utils.parameter import trim_parameter_jacobian_values
 
 
 def _crow_to_row_indices(crow_indices: torch.Tensor) -> torch.Tensor:
@@ -289,23 +290,19 @@ def jacobian(output, params):
         res = []
         for param in params:
             if hasattr(param, 'jactrace'):
-                if getattr(param, 'trim_SE3_grad', False):
-                    if isinstance(param.jactrace, tuple):
-                        values = param.jactrace[1]
-                        if values.shape[-1] == param.shape[-1]:
-                            values = torch.cat([values[..., :6], values[..., 7:]], dim=-1)
-                        param.jactrace = (param.jactrace[0], values)
-                    elif isinstance(param.jactrace, torch.Tensor) and param.jactrace.layout == torch.sparse_bsr:
-                        values = param.jactrace.values()
-                        if values.shape[-1] == param.shape[-1]:
-                            values = torch.cat([values[..., :6], values[..., 7:]], dim=-1)
-                            param.jactrace = torch.sparse_bsr_tensor(
-                                col_indices=param.jactrace.col_indices(),
-                                crow_indices=param.jactrace.crow_indices(),
-                                values=values,
-                                size=(param.jactrace.shape[0], param.shape[0] * values.shape[-1]),
-                                device=param.device,
-                            )
+                if isinstance(param.jactrace, tuple):
+                    values = trim_parameter_jacobian_values(param, param.jactrace[1])
+                    param.jactrace = (param.jactrace[0], values)
+                elif isinstance(param.jactrace, torch.Tensor) and param.jactrace.layout == torch.sparse_bsr:
+                    values = trim_parameter_jacobian_values(param, param.jactrace.values())
+                    if values.shape != param.jactrace.values().shape:
+                        param.jactrace = torch.sparse_bsr_tensor(
+                            col_indices=param.jactrace.col_indices(),
+                            crow_indices=param.jactrace.crow_indices(),
+                            values=values,
+                            size=(param.jactrace.shape[0], param.shape[0] * values.shape[-1]),
+                            device=param.device,
+                        )
                 if type(param.jactrace) is tuple:
                     param.jactrace = construct_sbt(param.jactrace[1], param.shape[0], param.jactrace[0], type=torch.sparse_bsr)
                 res.append(param.jactrace)

--- a/bae/autograd/graph.py
+++ b/bae/autograd/graph.py
@@ -1,6 +1,7 @@
 
 from typing import Optional
 
+import pypose as pp
 import torch
 from torch.func import jacrev
 
@@ -109,6 +110,34 @@ def construct_sbt(jac_from_vmap, num, index: Optional[torch.Tensor], type=torch.
                                     size = (n * block_shape[0], num * block_shape[1]),
                                     device=index.device, dtype=jac_from_vmap.dtype)
 
+def _clear_jactrace(output, params):
+    seen = set()
+    stack = [output, *params]
+    while stack:
+        tensor = stack.pop()
+        if not isinstance(tensor, torch.Tensor) or id(tensor) in seen:
+            continue
+        seen.add(id(tensor))
+
+        if hasattr(tensor, 'jactrace'):
+            delattr(tensor, 'jactrace')
+
+        if not hasattr(tensor, 'optrace') or id(tensor) not in tensor.optrace:
+            continue
+
+        op = tensor.optrace[id(tensor)][0]
+        if op == 'map':
+            args = tensor.optrace[id(tensor)][2]
+            stack.extend(arg for arg in args if isinstance(arg, torch.Tensor))
+        elif op == 'index':
+            arg = tensor.optrace[id(tensor)][2]
+            if isinstance(arg, torch.Tensor):
+                stack.append(arg)
+        elif op == 'cat':
+            args = tensor.optrace[id(tensor)][2]
+            stack.extend(arg for arg in args if isinstance(arg, torch.Tensor))
+
+
 def amend_trace(arg, jac_trace: tuple):
     if hasattr(arg, 'jactrace'):  # convert to sparse_bsr needed for accumulation
         if type(arg.jactrace) is tuple and type(jac_trace) is tuple:
@@ -150,7 +179,8 @@ def backward(output_):
         if len(argnums) == 0:
             warning("No upstream parameters to compute jacobian")
             return
-        jac_blocks = torch.vmap(jacrev(func, argnums=argnums))(*args)
+        with pp.retain_ltype():
+            jac_blocks = torch.vmap(jacrev(func, argnums=argnums))(*args)
         for jacidx, argidx in enumerate(argnums):
             jac_block = jac_blocks[jacidx]
             arg = args[argidx]
@@ -253,38 +283,32 @@ def backward(output_):
 
 def jacobian(output, params):
     assert output.optrace[id(output)][0] in ('map', 'index', 'cat'), "Unsupported last operation in compute graph"
-    backward(output)
-    res = []
-    for param in params:
-        if hasattr(param, 'jactrace'):
-            if getattr(param, 'trim_SE3_grad', False):
-                if isinstance(param.jactrace, tuple):
-                    values = param.jactrace[1]
-                elif isinstance(param.jactrace, torch.Tensor) and param.jactrace.layout == torch.sparse_bsr:
-                    values = param.jactrace.values()
-                else:
-                    values = param.jactrace
-
-                if values.shape[-1] == 7:
-                    values = values[..., :6]
-                else:
-                    values = torch.cat([values[..., :6], values[..., 7:]], dim=-1)
-                
-                if isinstance(param.jactrace, tuple):
-                    param.jactrace = (param.jactrace[0], values)
-                elif isinstance(param.jactrace, torch.Tensor) and param.jactrace.layout == torch.sparse_bsr:
-                    param.jactrace = torch.sparse_bsr_tensor(
-                        col_indices=param.jactrace.col_indices(), 
-                        crow_indices=param.jactrace.crow_indices(),
-                        values=values,
-                        size=(param.jactrace.shape[0], param.shape[0] * values.shape[-1]),
-                        device=param.device,
-                    )
-                else:
-                    param.jactrace = values
-            if type(param.jactrace) is tuple:
-                param.jactrace = construct_sbt(param.jactrace[1], param.shape[0], param.jactrace[0], type=torch.sparse_bsr)
-            res.append(param.jactrace)
-            delattr(param, 'jactrace')
-            
-    return res
+    _clear_jactrace(output, params)
+    try:
+        backward(output)
+        res = []
+        for param in params:
+            if hasattr(param, 'jactrace'):
+                if getattr(param, 'trim_SE3_grad', False):
+                    if isinstance(param.jactrace, tuple):
+                        values = param.jactrace[1]
+                        if values.shape[-1] == param.shape[-1]:
+                            values = torch.cat([values[..., :6], values[..., 7:]], dim=-1)
+                        param.jactrace = (param.jactrace[0], values)
+                    elif isinstance(param.jactrace, torch.Tensor) and param.jactrace.layout == torch.sparse_bsr:
+                        values = param.jactrace.values()
+                        if values.shape[-1] == param.shape[-1]:
+                            values = torch.cat([values[..., :6], values[..., 7:]], dim=-1)
+                            param.jactrace = torch.sparse_bsr_tensor(
+                                col_indices=param.jactrace.col_indices(),
+                                crow_indices=param.jactrace.crow_indices(),
+                                values=values,
+                                size=(param.jactrace.shape[0], param.shape[0] * values.shape[-1]),
+                                device=param.device,
+                            )
+                if type(param.jactrace) is tuple:
+                    param.jactrace = construct_sbt(param.jactrace[1], param.shape[0], param.jactrace[0], type=torch.sparse_bsr)
+                res.append(param.jactrace)
+        return res
+    finally:
+        _clear_jactrace(output, params)

--- a/bae/optim/optimizer.py
+++ b/bae/optim/optimizer.py
@@ -1,5 +1,4 @@
 from functools import partial
-import math
 import torch
 from pypose.optim import LevenbergMarquardt as ppLM
 import pypose as pp
@@ -7,6 +6,7 @@ from ..autograd.graph import jacobian
 from ..autograd.function import TrackingTensor
 from ..sparse.py_ops import diagonal_op_
 from ..sparse.spgemm import CuSparse
+from ..utils.parameter import parameter_update_shape
 
 
 
@@ -58,16 +58,14 @@ class LM(ppLM):
         numels = []
         for param in params:
             if param.requires_grad:
-                if getattr(param, 'trim_SE3_grad', False):
-                    numels.append(math.prod(param.shape[:-1]) * (param.shape[-1] - 1))
-                else:
-                    numels.append(param.numel())
+                numels.append(torch.Size(parameter_update_shape(param)).numel())
         steps = step.split(numels)
         for (param, d) in zip(params, steps):
             if param.requires_grad:
+                step_view = d.view(parameter_update_shape(param))
                 if getattr(param, 'trim_SE3_grad', False):
-                    param[..., :7] = pp.SE3(param[..., :7]).add_(pp.se3(d.view(param.shape[0], -1)[..., :6]))
+                    param[..., :7] = pp.SE3(param[..., :7]).add_(pp.se3(step_view[..., :6]))
                     if param.shape[-1] > 7:
-                        param[:, 7:] += d.view(param.shape[0], -1)[:, 6:]
+                        param[:, 7:] += step_view[..., 6:]
                 else:
-                    param.add_(d.view(param.shape))
+                    param.add_(step_view)

--- a/bae/utils/parameter.py
+++ b/bae/utils/parameter.py
@@ -1,0 +1,24 @@
+import pypose as pp
+import torch
+
+
+def parameter_update_shape(param: torch.Tensor) -> torch.Size:
+    if param.ndim == 0:
+        return param.shape
+    if getattr(param, 'trim_SE3_grad', False):
+        return torch.Size((*param.shape[:-1], param.shape[-1] - 1))
+    if isinstance(param, pp.LieTensor):
+        return torch.Size((*param.shape[:-1], param.ltype.manifold[0]))
+    return param.shape
+
+
+def trim_parameter_jacobian_values(param: torch.Tensor, values: torch.Tensor) -> torch.Tensor:
+    if param.ndim == 0 or values.shape[-1] != param.shape[-1]:
+        return values
+    if getattr(param, 'trim_SE3_grad', False):
+        return torch.cat([values[..., :6], values[..., 7:]], dim=-1)
+    if isinstance(param, pp.LieTensor):
+        step_dim = int(param.ltype.manifold[0])
+        if step_dim != param.shape[-1]:
+            return values[..., :step_dim]
+    return values

--- a/pgo.py
+++ b/pgo.py
@@ -108,7 +108,6 @@ class PoseGraph(nn.Module):
     def __init__(self, nodes):
         super().__init__()
         self.nodes = nn.Parameter(TrackingTensor(nodes))
-        self.nodes.trim_SE3_grad = True
 
     def forward(self, edges, poses, infos):
         node1 = self.nodes[edges[..., 0]]

--- a/pgo.py
+++ b/pgo.py
@@ -157,7 +157,7 @@ if __name__ == '__main__':
     scheduler = StopOnPlateau(optimizer, steps=20, patience=3, decreasing=1e-7, verbose=True)
 
     pngname = os.path.join(args.save, args.dataname+'.png')
-    axlim = plot_and_save(graph.nodes.translation(), pngname, args.dataname)
+    plot_and_save(graph.nodes.translation(), pngname, args.dataname)
     axlim = None
     ### the 1st implementation: for customization and easy to extend
     start = torch.cuda.Event(enable_timing=True)

--- a/pgo.py
+++ b/pgo.py
@@ -98,7 +98,7 @@ def foo(poses, node1, node2, infos):
 
 @map_transform
 def foo(poses, node1, node2, infos):
-    residual = (pp.SE3(poses).Inv() @ pp.SE3(node1).Inv() @ pp.SE3(node2)).Log().tensor()
+    residual = (poses.Inv() @ node1.Inv() @ node2).Log().tensor()
     residual = infos @ residual[..., None]
     residual = residual[..., 0]
     return residual
@@ -158,7 +158,7 @@ if __name__ == '__main__':
     scheduler = StopOnPlateau(optimizer, steps=20, patience=3, decreasing=1e-7, verbose=True)
 
     pngname = os.path.join(args.save, args.dataname+'.png')
-    axlim = plot_and_save(pp.SE3(graph.nodes).translation(), pngname, args.dataname)
+    axlim = plot_and_save(graph.nodes.translation(), pngname, args.dataname)
     axlim = None
     ### the 1st implementation: for customization and easy to extend
     start = torch.cuda.Event(enable_timing=True)
@@ -174,7 +174,7 @@ if __name__ == '__main__':
     end.record()
     print('Time elapsed: %.3f ms'%(start.elapsed_time(end)))
     print('Final loss: %7f'%(loss.item()/2))
-    plot_and_save(pp.SE3(graph.nodes).translation(), name+'.png', title, axlim=axlim)
+    plot_and_save(graph.nodes.translation(), name+'.png', title, axlim=axlim)
     torch.save(graph.state_dict(), name+'.pt')
     write_ceres_txt(graph.nodes, name+'.txt')
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 from torch.utils.cpp_extension import CppExtension, CUDAExtension, BuildExtension
 
-VERSION = "0.1"
+VERSION = "0.2"
 
 def readme():
     """Read the README.md file for long description"""

--- a/tests/autograd/test_bal_jacobian.py
+++ b/tests/autograd/test_bal_jacobian.py
@@ -414,7 +414,7 @@ def _final_bal_per_pixel_error_fixed_first_camera_cat(
     camera_all = torch.cat([camera_se3_all, model.intrinsics.tensor()], dim=-1)
     return least_square_error(
         camera_all,
-        model.points.tensor(),
+        model.points_3d.tensor(),
         camera_idx,
         point_idx,
         points_2d,

--- a/tests/autograd/test_graph_jacobian.py
+++ b/tests/autograd/test_graph_jacobian.py
@@ -1,9 +1,10 @@
 import pytest
+import pypose as pp
 import torch
 from torch import nn
 from torch.func import jacrev
 
-from bae.autograd.function import TrackingTensor as Track
+from bae.autograd.function import TrackingTensor as Track, map_transform
 from bae.autograd.graph import jacobian as sparse_jacobian
 
 
@@ -29,6 +30,11 @@ class ToyResidual(nn.Module):
 def _flatten_jac(J: torch.Tensor) -> torch.Tensor:
     n, outdim, num, indim = J.shape
     return J.reshape(n * outdim, num * indim)
+
+
+@map_transform
+def _relative_se3_residual(poses: pp.LieTensor, node1: pp.LieTensor, node2: pp.LieTensor) -> torch.Tensor:
+    return (poses.Inv() @ node1.Inv() @ node2).Log().tensor()
 
 
 @pytest.mark.parametrize("device", ["cpu", "cuda"])
@@ -273,3 +279,72 @@ def test_sparse_jacobian_index_after_cat_matches_torch_jacrev(device: str):
     JA, JB = jacrev(f, argnums=(0, 1))(A0, B0)
     torch.testing.assert_close(JA_sparse.to_dense(), _flatten_jac(JA), rtol=1e-10, atol=1e-10)
     torch.testing.assert_close(JB_sparse.to_dense(), _flatten_jac(JB), rtol=1e-10, atol=1e-10)
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_tracking_lie_tensor_index_and_cat_preserve_ltype(device: str):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    torch.manual_seed(0)
+    dtype = torch.float64
+
+    nodes = nn.Parameter(Track(pp.randn_SE3(5, device=device, dtype=dtype)))
+    idx_a = torch.tensor([0, 2, 4], device=device, dtype=torch.int64)
+    idx_b = torch.tensor([1, 3, 4], device=device, dtype=torch.int64)
+
+    node_a = nodes[idx_a]
+    node_b = nodes[idx_b]
+    cat = torch.cat([node_a, node_b], dim=0)
+
+    assert isinstance(nodes, Track)
+    assert isinstance(nodes, pp.LieTensor)
+    assert isinstance(node_a, Track)
+    assert isinstance(node_a, pp.LieTensor)
+    assert type(node_a.ltype) is type(nodes.ltype)
+    assert hasattr(node_a, "optrace")
+    assert node_a.optrace[id(node_a)][0] == "index"
+
+    assert node_a.tensor().shape == (idx_a.numel(), 7)
+    assert node_a.translation().shape == (idx_a.numel(), 3)
+    assert node_a.rotation().shape == (idx_a.numel(), 4)
+    assert isinstance(node_a.Inv(), pp.LieTensor)
+    assert isinstance(node_a.Log(), pp.LieTensor)
+
+    assert isinstance(cat, Track)
+    assert isinstance(cat, pp.LieTensor)
+    assert type(cat.ltype) is type(nodes.ltype)
+    assert hasattr(cat, "optrace")
+    assert cat.optrace[id(cat)][0] == "cat"
+    assert cat.translation().shape == (idx_a.numel() + idx_b.numel(), 3)
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_sparse_jacobian_matches_lie_tensor_pgo_residual(device: str):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    torch.manual_seed(0)
+    dtype = torch.float64
+
+    num_nodes = 5
+    num_edges = 4
+    nodes0 = pp.randn_SE3(num_nodes, device=device, dtype=dtype)
+    poses = pp.randn_SE3(num_edges, device=device, dtype=dtype)
+    idx1 = torch.tensor([0, 1, 2, 3], device=device, dtype=torch.int64)
+    idx2 = torch.tensor([1, 2, 3, 4], device=device, dtype=torch.int64)
+
+    model = nn.Parameter(Track(nodes0))
+    model.trim_SE3_grad = True
+    out = _relative_se3_residual(poses, model[idx1], model[idx2])
+
+    (J_sparse,) = sparse_jacobian(out, [model])
+
+    nodes_tensor = nodes0.tensor().detach().clone().requires_grad_(True)
+
+    def f(nodes_data: torch.Tensor) -> torch.Tensor:
+        nodes = pp.SE3(nodes_data)
+        return (poses.Inv() @ nodes[idx1].Inv() @ nodes[idx2]).Log().tensor()
+
+    (J_dense,) = jacrev(f, argnums=(0,))(nodes_tensor)
+    torch.testing.assert_close(J_sparse.to_dense(), _flatten_jac(J_dense[..., :6]), rtol=1e-10, atol=1e-10)

--- a/tests/autograd/test_graph_jacobian.py
+++ b/tests/autograd/test_graph_jacobian.py
@@ -335,7 +335,6 @@ def test_sparse_jacobian_matches_lie_tensor_pgo_residual(device: str):
     idx2 = torch.tensor([1, 2, 3, 4], device=device, dtype=torch.int64)
 
     model = nn.Parameter(Track(nodes0))
-    model.trim_SE3_grad = True
     out = _relative_se3_residual(poses, model[idx1], model[idx2])
 
     (J_sparse,) = sparse_jacobian(out, [model])


### PR DESCRIPTION
Summary

This PR makes TrackingTensor work transparently with PyPose LieTensor inputs so tracked SE(3) parameters keep their LieTensor API instead of degrading to plain tensors.

The main user-facing effect is that code like `self.nodes = nn.Parameter(TrackingTensor(nodes))` now preserves `pp.SE3` behavior through indexing, so PGO code can use:
```
  (poses.Inv() @ node1.Inv() @ node2).Log().tensor()
```
  instead of repeatedly re-wrapping everything with pp.SE3(...).

  What Changed

  - Made TrackingTensor(...) polymorphic for pp.LieTensor inputs.
  - Added an internal Lie-aware tracking subtype that preserves ltype across:
      - `nn.Parameter(...)`
      - tensor indexing
      - `torch.cat(..., dim=0)`
  - Kept the plain tensor tracking path unchanged for non-LieTensor inputs.
  - Updated the Jacobian graph path to preserve LieTensor metadata during `torch.vmap(jacrev(...))` via `pp.retain_ltype()`.
  - Kept Jacobian trace shapes unchanged during backward accumulation and only applied trim_SE3_grad when materializing the final Jacobian.
  - Added explicit jactrace cleanup before and after Jacobian construction to avoid stale trace state leaking across calls.
  - Simplified the PGO example to use native LieTensor operations directly.
  - Fixed a test typo in the BAL fixed-camera helper (model.points_3d vs model.points).

  Why

  Previously, wrapping a pp.LieTensor in TrackingTensor stripped its LieTensor type and ltype, which forced downstream code to re-cast with pp.SE3(...) before every Lie operation.

  This PR keeps the sparse-tracing behavior while preserving the LieTensor API, which makes the PGO path cleaner and less error-prone.

  - tracked LieTensor indexing/cat preserving ltype
  - PGO-style SE(3) residuals working without explicit pp.SE3(...) rewraps