### PR TITLE
Fix gitignore to exclude all bal_data everywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,7 @@ build/*
 bae.egg-info/*
 *.so
 *.pyc
-bal_data/*
-datapipes/bal_data/*
+**/bal_data/
 .ipynb_checkpoints/*
 .idea/*
 dump_Ab/*


### PR DESCRIPTION
**PROBLEM + AS-IS**

Once I run schur.py in root/examples, relevant outcome files in bal_data are being tracked by Git. Now, bal_data/* in gitignore can't exclude itself in lower level directories.

<img width="363" height="342" alt="Screenshot 2026-06-02 at 7 18 53 PM" src="https://github.com/user-attachments/assets/c317bcf5-6f56-49b5-9796-c49aaca8db04" />


<img width="401" height="540" alt="Screenshot 2026-06-02 at 7 23 06 PM" src="https://github.com/user-attachments/assets/b6111685-08fa-4789-a0e0-3ad71d9c856d" />

----------------


**TO-BE**

By adding **/bal_data/  and removing bal_data/* in gitignore, it's possible to exclude all bal_data in Git tracking

<img width="450" height="568" alt="image" src="https://github.com/user-attachments/assets/67ab315f-dbe1-43ae-aed6-12e80cea4537" />

